### PR TITLE
corrected image path on single item detail page; reformatted price

### DIFF
--- a/client/components/SingleItemDetail.js
+++ b/client/components/SingleItemDetail.js
@@ -26,10 +26,9 @@ export class SingleItemDetail extends Component {
     const {name, description, image, price} = this.props.item.item;
     return (
       <div>
-        <h1>YOU ARE HERE</h1>
         <h2>{name}</h2>
-        <img src={image} />
-        <h4>{price}</h4>
+        <img src={`../${image}`} />
+        <h4>${price / 100}</h4>
         <p>{description}</p>
 
         <button type="submit" onClick={this.handleClick}>


### PR DESCRIPTION
Changed path to image source so it now displays correctly.
Changed format for price to $(price / 100). We may want to reformat our prices so they are all in integer dollars instead of pennies.