### PR TITLE
fix appearance of price in all products view so it is in dollars, not…

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -25,7 +25,7 @@ export class SingleProduct extends Component {
             {' '}
             <img src={image} />{' '}
           </Link>
-          <li>{price}</li>
+          <li>${price / 100}</li>
         </ul>
         <button type="submit" onClick={this.handleClick}>
           Add to Cart


### PR DESCRIPTION
… cents

Changed the appearance of price on the all products page so it displays in dollars rather than cents. Did **not** change the value of price.

All unit tests continue to run successfully.