### PR TITLE
feat: closes #106, link to single product from name or image

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -19,7 +19,9 @@ export class SingleProduct extends Component {
     return (
       <div>
         <ul key={id}>
-          <li>{name}</li>
+          <li>
+            <Link to={`/products/${id}`}>{name}</Link>
+          </li>
           <li>{description}</li>
           <Link to={`/products/${id}`}>
             {' '}


### PR DESCRIPTION
Added <Link> component to name in <SingleProduct> component so a user can navigate to the <SingleProductDetail> view by clicking either the name or the image for the item. Fixes #106. 
