### PR TITLE
fix ambiguous spacing in navbar.js

### DIFF
--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -8,8 +8,7 @@ const Navbar = ({handleClick, isLoggedIn}) => (
   <div className="main_nav_container">
     <div className="logo_container">
       <Link to="/">
-        Shiny
-        <span>Objects</span>
+        Shiny <span>Objects</span>
       </Link>
     </div>
 


### PR DESCRIPTION
remove linebreak before `<span>` component in navbar.js to avoid linter message "ambiguous spacing"